### PR TITLE
deleting extraneous regex clause

### DIFF
--- a/lib/util_mustache.js
+++ b/lib/util_mustache.js
@@ -83,10 +83,6 @@ partialKeyStr += '([\\w\\-\\.\\/~]+)';
 // alphanumerics, hyphens, or pipes
 partialKeyStr += '(\\:[\\w\\-|]+)?';
 
-// an optional group of characters starting with a colon, followed by >0
-// alphanumerics or hyphens
-partialKeyStr += '(\\:[\\w\\-]+)?';
-
 // an optional group of characters starting with >=0 whitespaces, followed by
 // an opening parenthesis, followed by any number of characters that are not
 // closing parentheses, followed by a closing parenthesis


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #

Summary of changes:
@geoffp @bmuenzenmeyer 
I'm pretty sure when I broke these regexes into more grokable chunks, my only modification was the division and documentation. The original regexes in their final form were not altered. However, now that I'm actually reusing these and looking at them more carefully, I found this chunk as being possibly extraneous and want to pull request its deletion.

Do Pattern Lab partials ever have 2 colons?

Please review and provide any feedback. Thanks.
