### PR TITLE
Parametered partials hogan

### DIFF
--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -134,7 +134,7 @@ var engine_mustache = {
     var i;
     var j;
     var pa = pattern_assembler;
-    var partials = patternlab.partialsCompiled;
+    var partials = patternlab.partials;
     var regex;
     var renderedPartial;
 
@@ -183,8 +183,8 @@ var engine_mustache = {
 
       registered = false;
 
-      for (j in patternlab.partialsCompiled) {
-        if (patternlab.partialsCompiled.hasOwnProperty(j)) {
+      for (j in patternlab.partials) {
+        if (patternlab.partials.hasOwnProperty(j)) {
           if (j === partial) {
             registered = true;
             break;
@@ -205,7 +205,7 @@ var engine_mustache = {
           }
         }
 
-        patternlab.partialsCompiled[partial] = {
+        patternlab.partials[partial] = {
           partial: exports.findPartial(partial),
           params: params,
           content: ''

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -142,7 +142,7 @@ var engine_mustache = {
       if (partials.hasOwnProperty(i)) {
         // escape the parametered tags within partials by changing delimiters to unicodes
         // for start-of-text and end-of-text
-        escapedPartial = pa.findPartial(partials[i].partial, patternlab).template;
+        escapedPartial = pa.findPartial(partials[i].partial, patternlab).extendedTemplate;
         escapedPartial = '{{=\u0002 \u0003=}}' + escapedPartial;
 
         for (j in partials[i].params) {
@@ -155,7 +155,7 @@ var engine_mustache = {
           }
         }
 
-        partials[i].template = this.renderPattern(escapedPartial, partials[i].params);
+        partials[i].content = this.renderPattern(escapedPartial, partials[i].params);
       }
     }
   },
@@ -197,7 +197,7 @@ var engine_mustache = {
         tag: partial,
         partial: exports.findPartial(partial),
         params: params,
-        template: ''
+        content: ''
       };
     }
   },

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -132,6 +132,26 @@ var engine_mustache = {
     return foundPatternPartial;
   },
 
+  /**
+   * In order to quickly identify partials, register them keyed by the string 
+   * literal of their inclusion tag (including curly braces).
+   * The steps on a high-level are as follows:
+   *   * A .partials property of type object has been added to patternlab object
+   *     in an earlier step. We will be registering partials here.
+   *   * Iterate through each pattern looking for partials.
+   *   * If they are found, create a partials object with these properties:
+   *       * partial {string} The string taken from the tag stripped of curly
+   *           braces, parameters, and style modifiers
+   *       * params {object} The Pattern Lab syntaxed partial parameters parsed
+   *           and converted into a JS object
+   *       * content {string} The content which will replace the tag - this will
+   *           be added in the following preprocess step
+   *   * Add this object to patternlab.partials keyed by the entire tag.
+   *   * Be sure not to waste cycles on registering duplicates.
+   *
+   * @param {object} pattern A pattern object
+   * @param {object} patternlab The patternlab object
+   */
   registerPartial: function (pattern, patternlab) {
     var exports = module.exports;
     var i;
@@ -185,6 +205,26 @@ var engine_mustache = {
     }
   },
 
+
+  /**
+   * An additional preprocess step is required after registration in order to
+   * prevent unnecessary recursion and especially infinite recursion. 
+   * The steps on a high-level are as follows:
+   *   * Iterate through patternlab.partials.
+   *   * Match each member of patternlab.partials with the its corresponding
+   *     pattern in patternlab.patterns.
+   *   * Check if the partial has any params. These params need to be rendered
+   *     immediately so any true conditions they express persist without being
+   *     enclosed in tags. Any false conditions are deleted.
+   *   * To render only parametered tags, replace their delimiters.
+   *       * Replace {{ with the Unicode for Start Of Text.
+   *       * Replace }} with the Unicode for End Of Text.
+   *   * Render.
+   *   * Add the rendered content to the partials object.
+   *
+   * @param {object} pattern_assembler A constructed instance of the pattern_assembler module
+   * @param {object} patternlab The patternlab object
+   */
   preprocessPartials: function (pattern_assembler, patternlab) {
     var escapedKey;
     var escapedPartial;

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -39,6 +39,10 @@ var engine_mustache = {
   findListItemsRE: utilMustache.listItemsRE,
   findPartialRE: utilMustache.partialRE,
 
+  escapeReservedRegexChars: function (regexStr) {
+    return regexStr.replace(/[.*+?^${}()|[\]\\\/]/g, '\\$&');
+  },
+
   // render it
   renderPattern: function renderPattern(pattern, data, partials) {
     var toRender;
@@ -199,7 +203,7 @@ var engine_mustache = {
 
         for (j in partials[i].params) {
           if (partials[i].params.hasOwnProperty(j)) {
-            escapedKey = utilMustache.escapeReservedRegexChars(j);
+            escapedKey = this.escapeReservedRegexChars(j);
             regex = new RegExp('\\{\\{(\\S?\\s*' + escapedKey + ')', 'g');
             escapedPartial = escapedPartial.replace(regex, '\u0002$1');
             regex = new RegExp('(' + escapedKey + '\\s*)\\}?\\}\\}', 'g');

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -19,12 +19,13 @@
 
 "use strict";
 
-var Mustache = require('mustache');
+var Hogan = require('hogan.js');
+var JSON5 = require('json5');
 var utilMustache = require('./util_mustache');
 
 var engine_mustache = {
-  engine: Mustache,
-  engineName: 'mustache',
+  engine: Hogan,
+  engineName: 'hogan',
   engineFileExtension: '.mustache',
 
   // partial expansion is only necessary for Mustache templates that have
@@ -40,11 +41,24 @@ var engine_mustache = {
 
   // render it
   renderPattern: function renderPattern(pattern, data, partials) {
+    var toRender;
+
+    if (typeof pattern === 'string') {
+      toRender = pattern;
+    } else if (pattern.extendedTemplate && typeof pattern.extendedTemplate === 'string') {
+      toRender = pattern.extendedTemplate;
+    } else {
+      debugger;
+      console.log("e = renderPattern() requires a string or a pattern object as its first argument!");
+    }
+
     try {
+      var compiled = Hogan.compile(toRender);
+
       if (partials) {
-        return Mustache.render(pattern.extendedTemplate, data, partials);
+        return compiled.render(data, partials);
       }
-      return Mustache.render(pattern.extendedTemplate, data);
+      return compiled.render(data);
     } catch (e) {
       debugger;
       console.log("e = ", e);
@@ -62,8 +76,8 @@ var engine_mustache = {
     var matches;
     if (typeof pattern === 'string') {
       matches = pattern.match(regex);
-    } else if (typeof pattern === 'object' && typeof pattern.template === 'string') {
-      matches = pattern.template.match(regex);
+    } else if (typeof pattern === 'object' && typeof pattern.extendedTemplate === 'string') {
+      matches = pattern.extendedTemplate.match(regex);
     }
     return matches;
   },
@@ -111,6 +125,85 @@ var engine_mustache = {
     foundPatternPartial = foundPatternPartial.split(':')[0];
 
     return foundPatternPartial;
+  },
+
+  preprocessPartials: function (pattern_assembler, patternlab) {
+    var compiled;
+    var escapedKey;
+    var escapedPartial;
+    var i;
+    var j;
+    var pa = pattern_assembler;
+    var partials = patternlab.partialsCompiled;
+    var regex;
+    var renderedPartial;
+
+    for (i in partials) {
+      if (partials.hasOwnProperty(i)) {
+        // escape the parametered tags within partials by changing delimiters to unicodes
+        // for start-of-text and end-of-text
+        escapedPartial = pa.findPartial(partials[i].partial, patternlab).template;
+        escapedPartial = '{{=\u0002 \u0003=}}' + escapedPartial;
+
+        for (j in partials[i].params) {
+          if (partials[i].params.hasOwnProperty(j)) {
+            escapedKey = this.escapeReservedRegexChars(j);
+            regex = new RegExp('\\{\\{(\\S?\\s*' + escapedKey + ')', 'g');
+            escapedPartial = escapedPartial.replace(regex, '\u0002$1');
+            regex = new RegExp('(' + escapedKey + '\\s*)\\}\\}', 'g');
+            escapedPartial = escapedPartial.replace(regex, '$1\u0003');
+          }
+        }
+
+        partials[i].template = this.renderPattern(escapedPartial, partials[i].params);
+      }
+    }
+  },
+
+  registerPartial: function (pattern, patternlab) {
+    var exports = module.exports;
+    var leftParen;
+    var rightParen;
+    var paramString;
+    var params;
+    var partialName;
+    var partial;
+    var partialKey;
+    var partials = exports.findPartials(pattern);
+
+    if (!partials) {
+      return;
+    }
+
+    for (var i = 0; i < partials.length; i++) {
+      params = null;
+      partial = partials[i];
+      partialKey = partial.replace(/^\{\{>\s*/, '').replace(/\s*\}\}$/, '');
+
+      // identify and save params submitted with this partial
+      leftParen = partial.indexOf('(');
+      if (leftParen > -1) {
+        rightParen = partial.lastIndexOf(')');
+        paramString = '{' + partial.substring(leftParen + 1, rightParen) + '}';
+        try {
+          params = JSON5.parse(utilMustache.paramToJson(paramString));
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      // using Handlebars' convention for the place to register partials
+      patternlab.partialsCompiled[partialKey] = {
+        tag: partial,
+        partial: exports.findPartial(partial),
+        params: params,
+        template: ''
+      };
+    }
+  },
+
+  escapeReservedRegexChars: function (regexStr) {
+    return regexStr.replace(/[.*+?^${}()|[\]\\\/]/g, '\\$&');
   }
 };
 

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -211,8 +211,8 @@ var engine_mustache = {
    * prevent unnecessary recursion and especially infinite recursion. 
    * The steps on a high-level are as follows:
    *   * Iterate through patternlab.partials.
-   *   * Match each member of patternlab.partials with the its corresponding
-   *     pattern in patternlab.patterns.
+   *   * Match each member of patternlab.partials with its corresponding pattern
+   *     in patternlab.patterns.
    *   * Check if the partial has any params. These params need to be rendered
    *     immediately so any true conditions they express persist without being
    *     enclosed in tags. Any false conditions are deleted.

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -240,7 +240,7 @@ var engine_mustache = {
       if (partials.hasOwnProperty(i)) {
         // escape the parametered tags within partials by changing delimiters to unicodes
         // for start-of-text and end-of-text
-        template = pa.findPartial(partials[i].partial, patternlab).extendedTemplate;
+        template = pa.getPartial(partials[i].partial, patternlab).extendedTemplate;
         escapedPartial = '{{=\u0002 \u0003=}}' + template;
 
         for (j in partials[i].params) {

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -228,22 +228,26 @@ var engine_mustache = {
   preprocessPartials: function (pattern_assembler, patternlab) {
     var escapedKey;
     var escapedPartial;
+    var hasParam = false;
     var i;
     var j;
     var pa = pattern_assembler;
     var partials = patternlab.partials;
+    var template;
     var regex;
 
     for (i in partials) {
       if (partials.hasOwnProperty(i)) {
         // escape the parametered tags within partials by changing delimiters to unicodes
         // for start-of-text and end-of-text
-        escapedPartial = pa.findPartial(partials[i].partial, patternlab).extendedTemplate;
-        escapedPartial = '{{=\u0002 \u0003=}}' + escapedPartial;
+        template = pa.findPartial(partials[i].partial, patternlab).extendedTemplate;
+        escapedPartial = '{{=\u0002 \u0003=}}' + template;
 
         for (j in partials[i].params) {
           if (partials[i].params.hasOwnProperty(j)) {
+            hasParam = true;
             escapedKey = this.escapeReservedRegexChars(j);
+
             //apply replacement based on allowable characters from lines 78 and 79 of mustache.js
             //of the Mustache for JS project.
             regex = new RegExp('\\{\\{([\\{#\\^\\/&]?\\s*' + escapedKey + '\\s*)\\}?\\}\\}', 'g');
@@ -251,7 +255,11 @@ var engine_mustache = {
           }
         }
 
-        partials[i].content = this.renderPattern(escapedPartial, partials[i].params);
+        if (hasParam) {
+          partials[i].content = this.renderPattern(escapedPartial, partials[i].params);
+        } else {
+          partials[i].content = template;
+        }
       }
     }
   }

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -45,7 +45,7 @@ var engine_mustache = {
 
     if (typeof pattern === 'string') {
       toRender = pattern;
-    } else if (pattern.extendedTemplate && typeof pattern.extendedTemplate === 'string') {
+    } else if (typeof pattern.extendedTemplate === 'string') {
       toRender = pattern.extendedTemplate;
     } else {
       debugger;
@@ -162,43 +162,55 @@ var engine_mustache = {
 
   registerPartial: function (pattern, patternlab) {
     var exports = module.exports;
+    var i;
+    var j;
     var leftParen;
     var rightParen;
     var paramString;
     var params;
     var partialName;
     var partial;
-    var partialKey;
     var partials = exports.findPartials(pattern);
+    var registered;
 
     if (!partials) {
       return;
     }
 
-    for (var i = 0; i < partials.length; i++) {
+    for (i = 0; i < partials.length; i++) {
       params = null;
       partial = partials[i];
-      partialKey = partial.replace(/^\{\{>\s*/, '').replace(/\s*\}\}$/, '');
 
-      // identify and save params submitted with this partial
-      leftParen = partial.indexOf('(');
-      if (leftParen > -1) {
-        rightParen = partial.lastIndexOf(')');
-        paramString = '{' + partial.substring(leftParen + 1, rightParen) + '}';
-        try {
-          params = JSON5.parse(utilMustache.paramToJson(paramString));
-        } catch (err) {
-          console.error(err);
+      registered = false;
+
+      for (j in patternlab.partialsCompiled) {
+        if (patternlab.partialsCompiled.hasOwnProperty(j)) {
+          if (j === partial) {
+            registered = true;
+            break;
+          }
         }
       }
 
-      // using Handlebars' convention for the place to register partials
-      patternlab.partialsCompiled[partialKey] = {
-        tag: partial,
-        partial: exports.findPartial(partial),
-        params: params,
-        content: ''
-      };
+      if (!registered) {
+        // identify and save params submitted with this partial
+        leftParen = partial.indexOf('(');
+        if (leftParen > -1) {
+          rightParen = partial.lastIndexOf(')');
+          paramString = '{' + partial.substring(leftParen + 1, rightParen) + '}';
+          try {
+            params = JSON5.parse(utilMustache.paramToJson(paramString));
+          } catch (err) {
+            console.error(err);
+          }
+        }
+
+        patternlab.partialsCompiled[partial] = {
+          partial: exports.findPartial(partial),
+          params: params,
+          content: ''
+        };
+      }
     }
   },
 

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -63,6 +63,7 @@ var engine_mustache = {
       debugger;
       console.log("e = ", e);
     }
+    return undefined;
   },
 
   /**
@@ -128,7 +129,6 @@ var engine_mustache = {
   },
 
   preprocessPartials: function (pattern_assembler, patternlab) {
-    var compiled;
     var escapedKey;
     var escapedPartial;
     var i;
@@ -136,7 +136,6 @@ var engine_mustache = {
     var pa = pattern_assembler;
     var partials = patternlab.partials;
     var regex;
-    var renderedPartial;
 
     for (i in partials) {
       if (partials.hasOwnProperty(i)) {
@@ -168,7 +167,6 @@ var engine_mustache = {
     var rightParen;
     var paramString;
     var params;
-    var partialName;
     var partial;
     var partials = exports.findPartials(pattern);
     var registered;

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -128,37 +128,6 @@ var engine_mustache = {
     return foundPatternPartial;
   },
 
-  preprocessPartials: function (pattern_assembler, patternlab) {
-    var escapedKey;
-    var escapedPartial;
-    var i;
-    var j;
-    var pa = pattern_assembler;
-    var partials = patternlab.partials;
-    var regex;
-
-    for (i in partials) {
-      if (partials.hasOwnProperty(i)) {
-        // escape the parametered tags within partials by changing delimiters to unicodes
-        // for start-of-text and end-of-text
-        escapedPartial = pa.findPartial(partials[i].partial, patternlab).extendedTemplate;
-        escapedPartial = '{{=\u0002 \u0003=}}' + escapedPartial;
-
-        for (j in partials[i].params) {
-          if (partials[i].params.hasOwnProperty(j)) {
-            escapedKey = this.escapeReservedRegexChars(j);
-            regex = new RegExp('\\{\\{(\\S?\\s*' + escapedKey + ')', 'g');
-            escapedPartial = escapedPartial.replace(regex, '\u0002$1');
-            regex = new RegExp('(' + escapedKey + '\\s*)\\}\\}', 'g');
-            escapedPartial = escapedPartial.replace(regex, '$1\u0003');
-          }
-        }
-
-        partials[i].content = this.renderPattern(escapedPartial, partials[i].params);
-      }
-    }
-  },
-
   registerPartial: function (pattern, patternlab) {
     var exports = module.exports;
     var i;
@@ -212,8 +181,35 @@ var engine_mustache = {
     }
   },
 
-  escapeReservedRegexChars: function (regexStr) {
-    return regexStr.replace(/[.*+?^${}()|[\]\\\/]/g, '\\$&');
+  preprocessPartials: function (pattern_assembler, patternlab) {
+    var escapedKey;
+    var escapedPartial;
+    var i;
+    var j;
+    var pa = pattern_assembler;
+    var partials = patternlab.partials;
+    var regex;
+
+    for (i in partials) {
+      if (partials.hasOwnProperty(i)) {
+        // escape the parametered tags within partials by changing delimiters to unicodes
+        // for start-of-text and end-of-text
+        escapedPartial = pa.findPartial(partials[i].partial, patternlab).extendedTemplate;
+        escapedPartial = '{{=\u0002 \u0003=}}' + escapedPartial;
+
+        for (j in partials[i].params) {
+          if (partials[i].params.hasOwnProperty(j)) {
+            escapedKey = utilMustache.escapeReservedRegexChars(j);
+            regex = new RegExp('\\{\\{(\\S?\\s*' + escapedKey + ')', 'g');
+            escapedPartial = escapedPartial.replace(regex, '\u0002$1');
+            regex = new RegExp('(' + escapedKey + '\\s*)\\}\\}', 'g');
+            escapedPartial = escapedPartial.replace(regex, '$1\u0003');
+          }
+        }
+
+        partials[i].content = this.renderPattern(escapedPartial, partials[i].params);
+      }
+    }
   }
 };
 

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -204,7 +204,9 @@ var engine_mustache = {
         for (j in partials[i].params) {
           if (partials[i].params.hasOwnProperty(j)) {
             escapedKey = this.escapeReservedRegexChars(j);
-            regex = new RegExp('\\{\\{(\\S?\\s*' + escapedKey + ')', 'g');
+            //apply replacement based on allowable characters from lines 78 and 79 of mustache.js
+            //of the Mustache for JS project.
+            regex = new RegExp('\\{\\{([\\{#\\^\\/&]?\\s*' + escapedKey + ')', 'g');
             escapedPartial = escapedPartial.replace(regex, '\u0002$1');
             regex = new RegExp('(' + escapedKey + '\\s*)\\}?\\}\\}', 'g');
             escapedPartial = escapedPartial.replace(regex, '$1\u0003');

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -202,7 +202,7 @@ var engine_mustache = {
             escapedKey = utilMustache.escapeReservedRegexChars(j);
             regex = new RegExp('\\{\\{(\\S?\\s*' + escapedKey + ')', 'g');
             escapedPartial = escapedPartial.replace(regex, '\u0002$1');
-            regex = new RegExp('(' + escapedKey + '\\s*)\\}\\}', 'g');
+            regex = new RegExp('(' + escapedKey + '\\s*)\\}?\\}\\}', 'g');
             escapedPartial = escapedPartial.replace(regex, '$1\u0003');
           }
         }

--- a/lib/engine_mustache.js
+++ b/lib/engine_mustache.js
@@ -206,10 +206,8 @@ var engine_mustache = {
             escapedKey = this.escapeReservedRegexChars(j);
             //apply replacement based on allowable characters from lines 78 and 79 of mustache.js
             //of the Mustache for JS project.
-            regex = new RegExp('\\{\\{([\\{#\\^\\/&]?\\s*' + escapedKey + ')', 'g');
-            escapedPartial = escapedPartial.replace(regex, '\u0002$1');
-            regex = new RegExp('(' + escapedKey + '\\s*)\\}?\\}\\}', 'g');
-            escapedPartial = escapedPartial.replace(regex, '$1\u0003');
+            regex = new RegExp('\\{\\{([\\{#\\^\\/&]?\\s*' + escapedKey + '\\s*)\\}?\\}\\}', 'g');
+            escapedPartial = escapedPartial.replace(regex, '\u0002$1\u0003');
           }
         }
 

--- a/lib/util_mustache.js
+++ b/lib/util_mustache.js
@@ -222,10 +222,10 @@ function paramToJson(pString) {
         //escaped those even further with their unicodes, it is safe to look
         //for wrapper pairs and conclude that their contents are values
         case '"':
-          regex = /^"(.|\s)*?"/;
+          regex = /^"[\S\s]*?"/;
           break;
         case '\'':
-          regex = /^'(.|\s)*?'/;
+          regex = /^'[\S\s]*?'/;
           break;
 
         //if there is no value wrapper, regex for alphanumerics, decimal

--- a/lib/util_mustache.js
+++ b/lib/util_mustache.js
@@ -96,12 +96,235 @@ partialKeyStr += '(\\s*\\([^\\)]*\\))?';
 partialKeyStr += '\\s*}}';
 var partialKeyRE = new RegExp(partialKeyStr, 'g');
 
+/**
+ * This function is really to accommodate the lax JSON-like syntax allowed by
+ * Pattern Lab PHP for parameter submissions to partials. Unfortunately, no
+ * easily searchable library was discovered for this. What we had to do was
+ * write a custom script to crawl through the parameter string, and wrap the
+ * keys and values in double-quotes as necessary.
+ * The steps on a high-level are as follows:
+ *   * Further escape all escaped quotes and colons. Use the string
+ *     representation of their unicodes for this. This has the added bonus
+ *     of being interpreted correctly by JSON5.parse() without further
+ *     modification. This will be useful later in the function.
+ *   * Once escaped quotes are out of the way, we know the remaining quotes
+ *     are either key/value wrappers or wrapped within those wrappers. We know
+ *     that remaining commas and colons are either delimiters, or wrapped
+ *     within quotes to not be recognized as such.
+ *   * A do-while loop crawls paramString to write keys to a keys array and
+ *     values to a values array.
+ *   * Start by parsing the first key. Determine the type of wrapping quote,
+ *     if any.
+ *   * By knowing the open wrapper, we know that the next quote of that kind
+ *     (if the key is wrapped in quotes), HAS to be the close wrapper.
+ *     Similarly, if the key is unwrapped, we know the next colon HAS to be
+ *     the delimiter between key and value.
+ *   * Save the key to the keys array.
+ *   * Next, search for a value. It will either be the next block wrapped in
+ *     quotes, or a string of alphanumerics, decimal points, or minus signs.
+ *   * Save the value to the values array.
+ *   * The do-while loop truncates the paramString value while parsing. Its
+ *     condition for completion is when the paramString is whittled down to an
+ *     empty string.
+ *   * After the keys and values arrays are built, a for loop iterates through
+ *     them to build the final paramStringWellFormed string.
+ *   * No quote substitution had been done prior to this loop. In this loop,
+ *     all keys are ensured to be wrapped in double-quotes. String values are
+ *     also ensured to be wrapped in double-quotes.
+ *   * Unescape escaped unicodes except for double-quotes. Everything beside
+ *     double-quotes will be wrapped in double-quotes without need for escape.
+ *   * Return paramStringWellFormed.
+ *
+ * @param {string} pString
+ * @returns {string} paramStringWellFormed
+ */
+function paramToJson(pString) {
+  var colonPos = -1;
+  var keys = [];
+  var paramString = pString; // to not reassign param
+  var paramStringWellFormed;
+  var quotePos = -1;
+  var regex;
+  var values = [];
+  var wrapper;
+
+  //replace all escaped double-quotes with escaped unicode
+  paramString = paramString.replace(/\\"/g, '\\u0022');
+
+  //replace all escaped single-quotes with escaped unicode
+  paramString = paramString.replace(/\\'/g, '\\u0027');
+
+  //replace all escaped colons with escaped unicode
+  paramString = paramString.replace(/\\:/g, '\\u0058');
+
+  //with escaped chars out of the way, crawl through paramString looking for
+  //keys and values
+  do {
+
+    //check if searching for a key
+    if (paramString[0] === '{' || paramString[0] === ',') {
+      paramString = paramString.substring(1, paramString.length).trim();
+
+      //search for end quote if wrapped in quotes. else search for colon.
+      //everything up to that position will be saved in the keys array.
+      switch (paramString[0]) {
+
+        //need to search for end quote pos in case the quotes wrap a colon
+        case '"':
+        case '\'':
+          wrapper = paramString[0];
+          quotePos = paramString.indexOf(wrapper, 1);
+          break;
+
+        default:
+          colonPos = paramString.indexOf(':');
+      }
+
+      if (quotePos > -1) {
+        keys.push(paramString.substring(0, quotePos + 1).trim());
+
+        //truncate the beginning from paramString and look for a value
+        paramString = paramString.substring(quotePos + 1, paramString.length).trim();
+
+        //unset quotePos
+        quotePos = -1;
+
+      } else if (colonPos > -1) {
+        keys.push(paramString.substring(0, colonPos).trim());
+
+        //truncate the beginning from paramString and look for a value
+        paramString = paramString.substring(colonPos, paramString.length);
+
+        //unset colonPos
+        colonPos = -1;
+
+      //if there are no more colons, and we're looking for a key, there is
+      //probably a problem. stop any further processing.
+      } else {
+        paramString = '';
+        break;
+      }
+    }
+
+    //now, search for a value
+    if (paramString[0] === ':') {
+      paramString = paramString.substring(1, paramString.length).trim();
+
+      //the only reason we're using regexes here, instead of indexOf(), is
+      //because we don't know if the next delimiter is going to be a comma or
+      //a closing curly brace. since it's not much of a performance hit to
+      //use regexes as sparingly as here, and it's much more concise and
+      //readable, we'll use a regex for match() and replace() instead of
+      //performing conditional logic with indexOf().
+      switch (paramString[0]) {
+
+        //since a quote of same type as its wrappers would be escaped, and we
+        //escaped those even further with their unicodes, it is safe to look
+        //for wrapper pairs and conclude that their contents are values
+        case '"':
+          regex = /^"(.|\s)*?"/;
+          break;
+        case '\'':
+          regex = /^'(.|\s)*?'/;
+          break;
+
+        //if there is no value wrapper, regex for alphanumerics, decimal
+        //points, and minus signs for exponential notation.
+        default:
+          regex = /^[\w\-\.]*/;
+      }
+      values.push(paramString.match(regex)[0].trim());
+
+      //truncate the beginning from paramString and continue either
+      //looking for a key, or returning
+      paramString = paramString.replace(regex, '').trim();
+
+      //exit do while if the final char is '}'
+      if (paramString === '}') {
+        paramString = '';
+        break;
+      }
+
+    //if there are no more colons, and we're looking for a value, there is
+    //probably a problem. stop any further processing.
+    } else {
+      paramString = '';
+      break;
+    }
+  } while (paramString);
+
+  //build paramStringWellFormed string for JSON parsing
+  paramStringWellFormed = '{';
+  for (var i = 0; i < keys.length; i++) {
+
+    //keys
+    //replace single-quote wrappers with double-quotes
+    if (keys[i][0] === '\'' && keys[i][keys[i].length - 1] === '\'') {
+      paramStringWellFormed += '"';
+
+      //any enclosed double-quotes must be escaped
+      paramStringWellFormed += keys[i].substring(1, keys[i].length - 1).replace(/"/g, '\\"');
+      paramStringWellFormed += '"';
+    } else {
+
+      //open wrap with double-quotes if no wrapper
+      if (keys[i][0] !== '"' && keys[i][0] !== '\'') {
+        paramStringWellFormed += '"';
+
+        //this is to clean up vestiges from Pattern Lab PHP's escaping scheme.
+        //F.Y.I. Pattern Lab PHP would allow special characters like question
+        //marks in parameter keys so long as the key was unwrapped and the
+        //special character escaped with a backslash. In Node, we need to wrap
+        //those keys and unescape those characters.
+        keys[i] = keys[i].replace(/\\/g, '');
+      }
+
+      paramStringWellFormed += keys[i];
+
+      //close wrap with double-quotes if no wrapper
+      if (keys[i][keys[i].length - 1] !== '"' && keys[i][keys[i].length - 1] !== '\'') {
+        paramStringWellFormed += '"';
+      }
+    }
+
+    //colon delimiter.
+    paramStringWellFormed += ':'; + values[i];
+
+    //values
+    //replace single-quote wrappers with double-quotes
+    if (values[i][0] === '\'' && values[i][values[i].length - 1] === '\'') {
+      paramStringWellFormed += '"';
+
+      //any enclosed double-quotes must be escaped
+      paramStringWellFormed += values[i].substring(1, values[i].length - 1).replace(/"/g, '\\"');
+      paramStringWellFormed += '"';
+
+    //for everything else, just add the value however it's wrapped
+    } else {
+      paramStringWellFormed += values[i];
+    }
+
+    //comma delimiter
+    if (i < keys.length - 1) {
+      paramStringWellFormed += ',';
+    }
+  }
+  paramStringWellFormed += '}';
+
+  //unescape escaped unicode except for double-quotes
+  paramStringWellFormed = paramStringWellFormed.replace(/\\u0027/g, '\'');
+  paramStringWellFormed = paramStringWellFormed.replace(/\\u0058/g, ':');
+
+  return paramStringWellFormed;
+}
+
 var utilMustache = {
   partialsRE: partialsRE,
   partialsWithStyleModifiersRE: partialsWithStyleModifiersRE,
   partialsWithPatternParametersRE: partialsWithPatternParametersRE,
   listItemsRE: listItemsRE,
-  partialKeyRE: partialKeyRE
+  partialKeyRE: partialKeyRE,
+  paramToJson: paramToJson
 };
 
 module.exports = utilMustache;

--- a/lib/util_mustache.js
+++ b/lib/util_mustache.js
@@ -96,10 +96,6 @@ partialKeyStr += '(\\s*\\([^\\)]*\\))?';
 partialKeyStr += '\\s*}}';
 var partialKeyRE = new RegExp(partialKeyStr, 'g');
 
-function escapeReservedRegexChars(regexStr) {
-  return regexStr.replace(/[.*+?^${}()|[\]\\\/]/g, '\\$&');
-}
-
 /**
  * This function is really to accommodate the lax JSON-like syntax allowed by
  * Pattern Lab PHP for parameter submissions to partials. Unfortunately, no
@@ -328,7 +324,6 @@ var utilMustache = {
   partialsWithPatternParametersRE: partialsWithPatternParametersRE,
   listItemsRE: listItemsRE,
   partialKeyRE: partialKeyRE,
-  escapeReservedRegexChars: escapeReservedRegexChars,
   paramToJson: paramToJson
 };
 

--- a/lib/util_mustache.js
+++ b/lib/util_mustache.js
@@ -96,6 +96,10 @@ partialKeyStr += '(\\s*\\([^\\)]*\\))?';
 partialKeyStr += '\\s*}}';
 var partialKeyRE = new RegExp(partialKeyStr, 'g');
 
+function escapeReservedRegexChars(regexStr) {
+  return regexStr.replace(/[.*+?^${}()|[\]\\\/]/g, '\\$&');
+}
+
 /**
  * This function is really to accommodate the lax JSON-like syntax allowed by
  * Pattern Lab PHP for parameter submissions to partials. Unfortunately, no
@@ -324,6 +328,7 @@ var utilMustache = {
   partialsWithPatternParametersRE: partialsWithPatternParametersRE,
   listItemsRE: listItemsRE,
   partialKeyRE: partialKeyRE,
+  escapeReservedRegexChars: escapeReservedRegexChars,
   paramToJson: paramToJson
 };
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "1.0.2",
   "main": "lib/engine_mustache.js",
   "dependencies": {
-    "mustache": "^2.2.0"
+    "hogan.js": "^3.0.2",
+    "json5": "^0.5.0"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "keywords": [
     "Pattern Lab",
     "Atomic Web Design",


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses https://github.com/pattern-lab/patternlab-node/issues/250

Summary of changes:
- Replace Mustache with Hogan for performance benefits
- patternMatcher must work with .extendedTemplate and not .template for recursive parametered partials to work
- new functions to register and preprocess partials
- paramToJson copied from main patternlab-node repo - its purpose it specific to pl's Mustache syntax
