### PR TITLE
findPartial finds partials with parameters with newlines

### DIFF
--- a/lib/util_mustache.js
+++ b/lib/util_mustache.js
@@ -12,8 +12,26 @@
 
 // the term "alphanumeric" includes underscores.
 
-// todo: document this exact regex long form.
-var partialsRE = new RegExp(/{{>\s*?([\w\-\.\/~]+)(?:\:[A-Za-z0-9-_|]+)?(?:(?:| )\(.*)?(?:\s*)?}}/g);
+// look for an opening mustache include tag, followed by >=0 whitespaces
+var partialsStr = '{{>\\s*';
+
+// one or more characters comprising any combination of alphanumerics,
+// hyphens, periods, slashses, and tildes
+partialsStr += '([\\w\\-\\.\\/~]+)';
+
+// an optional group comprising a colon followed by one or more characters
+// comprising any combination of alphanumerics,
+// hyphens, and pipes
+partialsStr += '(\\:[\\w\\-\\|]+)?';
+
+// a group of characters starting with >=0 whitespaces, followed by an opening
+// parenthesis, followed by any number of characters that are not closing
+// parentheses, followed by a closing parenthesis
+partialsStr += '(\\s*\\([^\\)]*\\))?';
+
+// look for >=0 whitespaces, followed by closing mustache tag
+partialsStr += '\\s*}}';
+var partialsRE = new RegExp(partialsStr, 'g');
 
 // look for an opening mustache include tag, followed by >=0 whitespaces
 var partialsWithStyleModifiersStr = '{{>\\s*';

--- a/lib/util_mustache.js
+++ b/lib/util_mustache.js
@@ -20,14 +20,13 @@ var partialsStr = '{{>\\s*';
 partialsStr += '([\\w\\-\\.\\/~]+)';
 
 // an optional group comprising a colon followed by one or more characters
-// comprising any combination of alphanumerics,
-// hyphens, and pipes
+// comprising any combination of alphanumerics, hyphens, and pipes
 partialsStr += '(\\:[\\w\\-\\|]+)?';
 
-// a group of characters starting with >=0 whitespaces, followed by an opening
-// parenthesis, followed by any number of characters that are not closing
-// parentheses, followed by a closing parenthesis
-partialsStr += '(\\s*\\([^\\)]*\\))?';
+// a optional group of characters starting with >=0 whitespaces, followed by an
+// opening parenthesis, followed by a lazy match of non-whitespace or whitespace
+// characters (to include newlines), followed by a closing parenthesis
+partialsStr += '(\\s*\\([\\S\\s]*?\\))?';
 
 // look for >=0 whitespaces, followed by closing mustache tag
 partialsStr += '\\s*}}';
@@ -47,10 +46,10 @@ partialsWithStyleModifiersStr += '(?!\\()';
 // of alphanumerics, hyphens, and pipes
 partialsWithStyleModifiersStr += '(\\:[\\w\\-\\|]+)';
 
-// an optional group of characters starting with >=0 whitespaces, followed by
-// an opening parenthesis, followed by any number of characters that are not
-// closing parentheses, followed by a closing parenthesis
-partialsWithStyleModifiersStr += '(\\s*\\([^\\)]*\\))?';
+// a optional group of characters starting with >=0 whitespaces, followed by an
+// opening parenthesis, followed by a lazy match of non-whitespace or whitespace
+// characters (to include newlines), followed by a closing parenthesis
+partialsWithStyleModifiersStr += '(\\s*\\([\\S\\s]*?\\))?';
 
 // look for >=0 whitespaces, followed by closing mustache tag
 partialsWithStyleModifiersStr += '\\s*}}';
@@ -64,14 +63,13 @@ var partialsWithPatternParametersStr = '{{>\\s*';
 partialsWithPatternParametersStr += '([\\w\\-\\.\\/~]+)';
 
 // an optional group comprising a colon followed by one or more characters
-// comprising any combination of alphanumerics,
-// hyphens, and pipes
+// comprising any combination of alphanumerics, hyphens, and pipes
 partialsWithPatternParametersStr += '(\\:[\\w\\-\\|]+)?';
 
-// a group of characters starting with >=0 whitespaces, followed by an opening
-// parenthesis, followed by any number of characters that are not closing
-// parentheses, followed by a closing parenthesis
-partialsWithPatternParametersStr += '(\\s*\\([^\\)]*\\))';
+// a group of characters starting with >=0 whitespaces, followed by an
+// opening parenthesis, followed by a lazy match of non-whitespace or whitespace
+// characters (to include newlines), followed by a closing parenthesis
+partialsWithPatternParametersStr += '(\\s*\\([\\S\\s)]*?\\))';
 
 // look for >=0 whitespaces, followed by closing mustache tag
 partialsWithPatternParametersStr += '\\s*}}';
@@ -118,8 +116,7 @@ var utilMustache = {
   partialsRE: partialsRE,
   partialsWithStyleModifiersRE: partialsWithStyleModifiersRE,
   partialsWithPatternParametersRE: partialsWithPatternParametersRE,
-  listItemsRE: listItemsRE,
-  partialKeyRE: partialKeyRE
+  listItemsRE: listItemsRE
 };
 
 module.exports = utilMustache;


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses pattern-lab/patternlab-node#250

Summary of changes:
In order to get #250 done, `findPartial` needs to find partials with parameters with newlines. Also, the broken apart and documented regex string has become indispensable.
